### PR TITLE
Percona support

### DIFF
--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -6,6 +6,92 @@
 class mysql::client::install {
 
   if $mysql::client::package_manage {
+    if $mysql::server::package_name == 'percona-server-client' {
+      class { 'apt': }
+
+      if ! defined(Apt::Source['percona-80']) {
+        apt::source { 'percona-80':
+          location => 'http://repo.percona.com/ps-80/apt/',
+          repos    => 'main',
+          key      => {
+            id     => '4D1BB29D63D98E422B2113B19334A25F8507EFA5',
+            source => 'https://www.percona.com/downloads/RPM-GPG-KEY-percona',
+          },
+          include => { src => false },
+        }
+      }
+
+      if ! defined(Apt::Source['percona_tools']) {
+        apt::source { 'percona_tools':
+          location => 'http://repo.percona.com/tools/apt/',
+          repos    => 'main',
+          key      => {
+            id     => '4D1BB29D63D98E422B2113B19334A25F8507EFA5',
+            source => 'https://www.percona.com/downloads/RPM-GPG-KEY-percona',
+          },
+          include => { src => false },
+        }
+      }
+
+      if ! defined(Exec['apt_update_percona']) {
+        exec { 'apt_update_percona':
+          command     => '/usr/bin/apt-get update',
+          refreshonly => true,
+          path        => ['/usr/bin', '/usr/sbin', '/bin'],
+        }
+      }
+
+      # Only chain the ones that actually exist:
+      if defined(Apt::Source['percona-80']) {
+        Apt::Source['percona-80'] -> Exec['apt_update_percona']
+      }
+      if defined(Apt::Source['percona_tools']) {
+        Apt::Source['percona_tools'] -> Exec['apt_update_percona']
+      }
+    }
+    elsif $mysql::server::package_name == 'percona-server-client-5.7' {
+      class { 'apt': }
+
+      if ! defined(Apt::Source['percona-5-7']) {
+        apt::source { 'percona-5-7':
+          location => 'http://repo.percona.com/ps-57/apt/',
+          repos    => 'main',
+          key      => {
+            id     => '4D1BB29D63D98E422B2113B19334A25F8507EFA5',
+            source => 'https://www.percona.com/downloads/RPM-GPG-KEY-percona',
+          },
+          include => { src => false },
+        }
+      }
+
+      if ! defined(Apt::Source['percona_tools']) {
+        apt::source { 'percona_tools':
+          location => 'http://repo.percona.com/tools/apt/',
+          repos    => 'main',
+          key      => {
+            id     => '4D1BB29D63D98E422B2113B19334A25F8507EFA5',
+            source => 'https://www.percona.com/downloads/RPM-GPG-KEY-percona',
+          },
+          include => { src => false },
+        }
+      }
+
+      if ! defined(Exec['apt_update_percona']) {
+        exec { 'apt_update_percona':
+          command     => '/usr/bin/apt-get update',
+          refreshonly => true,
+          path        => ['/usr/bin', '/usr/sbin', '/bin'],
+        }
+      }
+
+      # Only chain the ones that actually exist:
+      if defined(Apt::Source['percona-5-7']) {
+        Apt::Source['percona-5-7'] -> Exec['apt_update_percona']
+      }
+      if defined(Apt::Source['percona_tools']) {
+        Apt::Source['percona_tools'] -> Exec['apt_update_percona']
+      }
+    }
 
     package { 'mysql_client':
       ensure          => $mysql::client::package_ensure,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@
 # @api private
 #
 class mysql::params (
-  Optional[Enum['percona-80', 'percona-57']] $provider_override = undef,
+  Optional[Enum['percona-80']] $provider_override = undef,
 ) {
 
   $manage_config_file     = true
@@ -208,14 +208,7 @@ class mysql::params (
         $server_service_name     = 'mysql'
         $config_file             = '/etc/mysql/mysql.cnf'
         $includedir              = '/etc/mysql/mysql.conf.d'
-        $default_config_override = '/etc/mysql/my.cnf'
-      } elsif $provider_override == 'percona-57' {
-        $client_package_name     = 'percona-server-client-5.7'
-        $server_package_name     = 'percona-server-server-5.7'
-        $server_service_name     = 'mysql'
-        $config_file             = '/etc/my.cnf'
-        $includedir              = '/etc/my.cnf.d'
-        $default_config_override = '/etc/mysql/my.cnf'
+        $percona_config_override = '/etc/mysql/my.cnf'
       } elsif $provider == 'mariadb' {
         $client_package_name     = 'mariadb-client'
         $server_package_name     = 'mariadb-server'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,9 @@
 #
 # @api private
 #
-class mysql::params {
+class mysql::params (
+  Optional[Enum['percona-80', 'percona-57']] $provider_override = undef,
+) {
 
   $manage_config_file     = true
   $config_file_mode       = '0644'
@@ -257,6 +259,21 @@ class mysql::params {
         'bionic'           => 'ruby-mysql2',
         'focal'            => 'ruby-mysql2',
         default            => 'libmysql-ruby',
+      }
+
+      # Add some overrides for percona support
+      if $provider_override == 'percona-80' {
+        $client_package_name     = 'percona-server-client'
+        $server_package_name     = 'percona-server-server'
+        $server_service_name     = 'mysql'
+        $config_file             = '/etc/mysql/mysql.cnf'
+        $includedir              = '/etc/mysql/mysql.conf.d'
+      } elsif $provider_override == 'percona-57' {
+        $client_package_name     = 'percona-server-client-5.7'
+        $server_package_name     = 'percona-server-server-5.7'
+        $server_service_name     = 'mysql'
+        $config_file             = '/etc/my.cnf'
+        $includedir              = '/etc/my.cnf.d'
       }
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -200,23 +200,41 @@ class mysql::params (
       } else {
         $provider = 'mysql'
       }
-      if $provider == 'mariadb' {
+
+      # Add some overrides for percona support
+      if $provider_override == 'percona-80' {
+        $client_package_name     = 'percona-server-client'
+        $server_package_name     = 'percona-server-server'
+        $server_service_name     = 'mysql'
+        $config_file             = '/etc/mysql/mysql.cnf'
+        $includedir              = '/etc/mysql/mysql.conf.d'
+        $default_config_override = '/etc/mysql/my.cnf'
+      } elsif $provider_override == 'percona-57' {
+        $client_package_name     = 'percona-server-client-5.7'
+        $server_package_name     = 'percona-server-server-5.7'
+        $server_service_name     = 'mysql'
+        $config_file             = '/etc/my.cnf'
+        $includedir              = '/etc/my.cnf.d'
+        $default_config_override = '/etc/mysql/my.cnf'
+      } elsif $provider == 'mariadb' {
         $client_package_name     = 'mariadb-client'
         $server_package_name     = 'mariadb-server'
         $server_service_name     = 'mariadb'
+        $config_file             = '/etc/mysql/my.cnf'
+        $includedir              = '/etc/mysql/conf.d'
         $client_dev_package_name = 'libmariadbclient-dev'
         $daemon_dev_package_name = 'libmariadbd-dev'
       } else {
         $client_package_name     = 'mysql-client'
         $server_package_name     = 'mysql-server'
         $server_service_name     = 'mysql'
+        $config_file             = '/etc/mysql/my.cnf'
+        $includedir              = '/etc/mysql/conf.d'
         $client_dev_package_name = 'libmysqlclient-dev'
         $daemon_dev_package_name = 'libmysqld-dev'
       }
 
       $basedir                 = '/usr'
-      $config_file             = '/etc/mysql/my.cnf'
-      $includedir              = '/etc/mysql/conf.d'
       $datadir                 = '/var/lib/mysql'
       $log_error               = '/var/log/mysql/error.log'
       $pidfile                 = '/var/run/mysqld/mysqld.pid'
@@ -259,21 +277,6 @@ class mysql::params (
         'bionic'           => 'ruby-mysql2',
         'focal'            => 'ruby-mysql2',
         default            => 'libmysql-ruby',
-      }
-
-      # Add some overrides for percona support
-      if $provider_override == 'percona-80' {
-        $client_package_name     = 'percona-server-client'
-        $server_package_name     = 'percona-server-server'
-        $server_service_name     = 'mysql'
-        $config_file             = '/etc/mysql/mysql.cnf'
-        $includedir              = '/etc/mysql/mysql.conf.d'
-      } elsif $provider_override == 'percona-57' {
-        $client_package_name     = 'percona-server-client-5.7'
-        $server_package_name     = 'percona-server-server-5.7'
-        $server_service_name     = 'mysql'
-        $config_file             = '/etc/my.cnf'
-        $includedir              = '/etc/my.cnf.d'
       }
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -206,9 +206,10 @@ class mysql::params (
         $client_package_name     = 'percona-server-client'
         $server_package_name     = 'percona-server-server'
         $server_service_name     = 'mysql'
-        $config_file             = '/etc/mysql/mysql.cnf'
+        $config_file             = '/etc/mysql/mysql.conf.d/server.cnf'
         $includedir              = '/etc/mysql/mysql.conf.d'
-        $percona_config_override = '/etc/mysql/my.cnf'
+        $percona_config_override_mycnf = '/etc/mysql/my.cnf'
+        $percona_config_override_mysqlcnf = '/etc/mysql/mysql.cnf'
       } elsif $provider == 'mariadb' {
         $client_package_name     = 'mariadb-client'
         $server_package_name     = 'mariadb-server'

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -68,10 +68,10 @@ class mysql::server::config {
       selinux_ignore_defaults => true,
     }
 
-    if $mysql::params::default_config_override != undef {
+    if $mysql::params::provider_override == 'percona-80' {
       # Write a default my.cnf that percona expects
       file { 'mysql-config-file-percona':
-        path                    => $mysql::params::default_config_override,
+        path                    => $mysql::params::percona_config_override,
         content                 => template('mysql/percona-my.cnf.erb'),
         mode                    => $mysql::server::config_file_mode,
         owner                   => $mysql::server::mycnf_owner,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -59,20 +59,50 @@ class mysql::server::config {
   }
 
   if $mysql::server::manage_config_file  {
-    file { 'mysql-config-file':
-      path                    => $mysql::server::config_file,
-      content                 => template('mysql/my.cnf.erb'),
-      mode                    => $mysql::server::config_file_mode,
-      owner                   => $mysql::server::mycnf_owner,
-      group                   => $mysql::server::mycnf_group,
-      selinux_ignore_defaults => true,
-    }
-
     if $mysql::params::provider_override == 'percona-80' {
-      # Write a default my.cnf that percona expects
-      file { 'mysql-config-file-percona':
-        path                    => $mysql::params::percona_config_override,
+
+      # MySQL expects directory file to exist
+      file { '/etc/mysql/conf.d':
+        ensure                  => directory,
+        mode                    => $mysql::server::config_file_mode,
+        owner                   => $mysql::server::mycnf_owner,
+        group                   => $mysql::server::mycnf_group,
+      }
+
+      # Write our new custom config to 'includedir'
+      # (config_file and includedir not directly related, if one changes the other must be changed)
+      file { 'mysql-config-file':
+        path                    => $mysql::server::config_file,
+        content                 => template('mysql/percona_custom.cnf.erb'),
+        mode                    => $mysql::server::config_file_mode,
+        owner                   => $mysql::server::mycnf_owner,
+        group                   => $mysql::server::mycnf_group,
+        selinux_ignore_defaults => true,
+      }
+
+      # Write a default my.cnf and mysql.cnf that percona expects
+      file { 'mysql-config-file-percona-mycnf':
+        path                    => $mysql::params::percona_config_override_mycnf,
         content                 => template('mysql/percona-my.cnf.erb'),
+        mode                    => $mysql::server::config_file_mode,
+        owner                   => $mysql::server::mycnf_owner,
+        group                   => $mysql::server::mycnf_group,
+        selinux_ignore_defaults => true,
+      }
+
+      file { 'mysql-config-file-percona-mysqlcnf':
+        path                    => $mysql::params::percona_config_override_mysqlcnf,
+        content                 => template('mysql/percona-my.cnf.erb'),
+        mode                    => $mysql::server::config_file_mode,
+        owner                   => $mysql::server::mycnf_owner,
+        group                   => $mysql::server::mycnf_group,
+        selinux_ignore_defaults => true,
+      }
+
+    } else {
+      file { 'mysql-config-file':
+        path                    => $mysql::server::config_file,
+        content                 => template('mysql/my.cnf.erb'),
         mode                    => $mysql::server::config_file_mode,
         owner                   => $mysql::server::mycnf_owner,
         group                   => $mysql::server::mycnf_group,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -68,6 +68,18 @@ class mysql::server::config {
       selinux_ignore_defaults => true,
     }
 
+    if $mysql::params::default_config_override != undef {
+      # Write a default my.cnf that percona expects
+      file { 'mysql-config-file-percona':
+        path                    => $mysql::params::default_config_override,
+        content                 => template('mysql/percona-my.cnf.erb'),
+        mode                    => $mysql::server::config_file_mode,
+        owner                   => $mysql::server::mycnf_owner,
+        group                   => $mysql::server::mycnf_group,
+        selinux_ignore_defaults => true,
+      }
+    }
+
     # on mariadb systems, $includedir is not defined, but /etc/my.cnf.d has
     # to be managed to place the server.cnf there
     $configparentdir = dirname($mysql::server::config_file)

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -1,17 +1,96 @@
-# @summary 
-#   Private class for managing MySQL package.
-#
-# @api private
-#
 class mysql::server::install {
-
   if $mysql::server::package_manage {
 
+    if $mysql::server::package_name == 'percona-server-server' {
+      class { 'apt': }
+
+      if ! defined(Apt::Source['percona-80']) {
+        apt::source { 'percona-80':
+          location => 'http://repo.percona.com/ps-80/apt/',
+          repos    => 'main',
+          key      => {
+            id     => '4D1BB29D63D98E422B2113B19334A25F8507EFA5',
+            source => 'https://www.percona.com/downloads/RPM-GPG-KEY-percona',
+          },
+          include => { src => false },
+        }
+      }
+
+      if ! defined(Apt::Source['percona_tools']) {
+        apt::source { 'percona_tools':
+          location => 'http://repo.percona.com/tools/apt/',
+          repos    => 'main',
+          key      => {
+            id     => '4D1BB29D63D98E422B2113B19334A25F8507EFA5',
+            source => 'https://www.percona.com/downloads/RPM-GPG-KEY-percona',
+          },
+          include => { src => false },
+        }
+      }
+
+      if ! defined(Exec['apt_update_percona']) {
+        exec { 'apt_update_percona':
+          command     => '/usr/bin/apt-get update',
+          refreshonly => true,
+          path        => ['/usr/bin', '/usr/sbin', '/bin'],
+        }
+      }
+
+      # Only chain the ones that actually exist:
+      if defined(Apt::Source['percona-80']) {
+        Apt::Source['percona-80'] -> Exec['apt_update_percona']
+      }
+      if defined(Apt::Source['percona_tools']) {
+        Apt::Source['percona_tools'] -> Exec['apt_update_percona']
+      }
+    }
+    elsif $mysql::server::package_name == 'percona-server-server-5.7' {
+      class { 'apt': }
+
+      if ! defined(Apt::Source['percona-5-7']) {
+        apt::source { 'percona-5-7':
+          location => 'http://repo.percona.com/ps-57/apt/',
+          repos    => 'main',
+          key      => {
+            id     => '4D1BB29D63D98E422B2113B19334A25F8507EFA5',
+            source => 'https://www.percona.com/downloads/RPM-GPG-KEY-percona',
+          },
+          include => { src => false },
+        }
+      }
+
+      if ! defined(Apt::Source['percona_tools']) {
+        apt::source { 'percona_tools':
+          location => 'http://repo.percona.com/tools/apt/',
+          repos    => 'main',
+          key      => {
+            id     => '4D1BB29D63D98E422B2113B19334A25F8507EFA5',
+            source => 'https://www.percona.com/downloads/RPM-GPG-KEY-percona',
+          },
+          include => { src => false },
+        }
+      }
+
+      if ! defined(Exec['apt_update_percona']) {
+        exec { 'apt_update_percona':
+          command     => '/usr/bin/apt-get update',
+          refreshonly => true,
+          path        => ['/usr/bin', '/usr/sbin', '/bin'],
+        }
+      }
+
+      # Only chain the ones that actually exist:
+      if defined(Apt::Source['percona-5-7']) {
+        Apt::Source['percona-5-7'] -> Exec['apt_update_percona']
+      }
+      if defined(Apt::Source['percona_tools']) {
+        Apt::Source['percona_tools'] -> Exec['apt_update_percona']
+      }
+    }
+
     package { 'mysql-server':
-      ensure          => $mysql::server::package_ensure,
-      install_options => $mysql::server::install_options,
-      name            => $mysql::server::package_name,
+      name   => $mysql::server::package_name,
+      ensure => $mysql::server::package_ensure,
     }
   }
-
 }

--- a/templates/percona-my.cnf.erb
+++ b/templates/percona-my.cnf.erb
@@ -1,0 +1,14 @@
+# MANAGED BY PUPPET
+#
+# The Percona Server 8.0 configuration file.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+#
+#
+# * IMPORTANT: Additional settings that can override those from this file!
+#   The files must end with '.cnf', otherwise they'll be ignored.
+#
+
+!includedir /etc/mysql/conf.d/
+!includedir /etc/mysql/mysql.conf.d/

--- a/templates/percona_custom.cnf.erb
+++ b/templates/percona_custom.cnf.erb
@@ -1,0 +1,20 @@
+### MANAGED BY PUPPET ###
+
+<% @options.sort.map do |k,v| -%>
+<%   if v.is_a?(Hash) -%>
+[<%=   k %>]
+<%     v.sort.map do |ki, vi| -%>
+<%       if ki == 'ssl-disable' or (ki =~ /^ssl/ and v['ssl-disable'] == true) -%>
+<%         next %>
+<%       elsif vi == true or vi == '' -%>
+<%=        ki %>
+<%       elsif vi.is_a?(Array) -%>
+<%         vi.each do |vii| -%>
+<%=          ki %> = <%= vii %>
+<%         end -%>
+<%       elsif ![nil, '', :undef].include?(vi) -%>
+<%=        ki %> = <%= vi %>
+<%       end -%>
+<%     end -%>
+<%   end %>
+<% end -%>


### PR DESCRIPTION
# Update MySQL Puppet Module to Support Percona Config Path Change

## Description

Percona has changed the default location of the MySQL configuration file from `/etc/mysql/my.cnf` to `/etc/mysql/mysql.conf.d/`. This impacts configuration management in several ways:

- Custom config overrides may no longer be respected unless explicitly written to the new directory structure.
- Binary log (`binlog`) settings can change names or locations, which breaks replication.
- Our current Puppet module assumes `/etc/mysql/my.cnf` is the primary config file, which is no longer valid for Percona installations.

## Acceptance Criteria

- [x] Detect if the system is using Percona.
- [x] Update config templates and file resources to support `/etc/mysql/mysql.conf.d/`.
- [x] Ensure `binlog` settings are correctly applied and do not break replication.
- [ ] Provide a migration note or helper to transition existing config files to the new structure.
- [ ] Add automated tests for both the legacy and new config layouts.

## Additional Notes

This change has already caused replication issues due to missing or renamed `binlog` settings. Backward compatibility or an upgrade migration strategy is necessary.